### PR TITLE
Expose searchTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ And then import `TreeMenu` and use it. By default you only need to provide `data
 import TreeMenu from 'react-simple-tree-menu'
 ...
 // import default minimal styling or your own styling
-import '../node_modules/react-simple-tree-menu/main.css';
+import '../node_modules/react-simple-tree-menu/dist/main.css';
 // Use the default minimal UI
 <TreeMenu data={treeData} />
 
@@ -176,11 +176,12 @@ Note the difference between the state `active` and `focused`. ENTER is equivalen
 
 ### ChildrenProps
 
-| props  | description                                                                                              | type                                   | default |
-| ------ | -------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------- |
-| search | A function that takes a string to filter the label of the item (only available if `hasSearch` is `true`) | (value: string) => void                | -       |
-| items  | An array of `TreeMenuItem`                                                                               | TreeMenuItem[]                         | []      |
-| reset  | A function that resets the `openNodes`, by default it will close all nodes                               | (openNodes: string[]) => void          | -       |
+| props      | description                                                                                              | type                                   | default |
+| ---------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------- |
+| search     | A function that takes a string to filter the label of the item (only available if `hasSearch` is `true`) | (value: string) => void                | -       |
+| searchTerm | the search term that is currently applied (only available if `hasSearch` is `true`)                      | string                                 | -       |
+| items      | An array of `TreeMenuItem`                                                                               | TreeMenuItem[]                         | []      |
+| reset      | A function that resets the `openNodes`, by default it will close all nodes                               | (openNodes: string[]) => void          | -       |
 
 ### TreeMenuItem
 

--- a/src/TreeMenu/index.tsx
+++ b/src/TreeMenu/index.tsx
@@ -56,7 +56,7 @@ class TreeMenu extends React.Component<TreeMenuProps, TreeMenuState> {
     const { initialOpenNodes } = this.props;
     const openNodes =
       (Array.isArray(newOpenNodes) && newOpenNodes) || initialOpenNodes || [];
-    this.setState({ openNodes });
+    this.setState({ openNodes, searchTerm: '' });
   };
 
   search = (value: string) => {
@@ -105,7 +105,7 @@ class TreeMenu extends React.Component<TreeMenuProps, TreeMenuState> {
 
   render() {
     const { children, hasSearch, onClickItem } = this.props;
-    const { focusKey, activeKey, openNodes } = this.state;
+    const { focusKey, activeKey, searchTerm } = this.state;
     const items = this.generateItems();
     const renderedChildren = children || defaultChildren;
     const focusIndex = items.findIndex(item => item.key === (focusKey || activeKey));
@@ -154,7 +154,7 @@ class TreeMenu extends React.Component<TreeMenuProps, TreeMenuState> {
       <KeyDown {...keyDownProps}>
         {renderedChildren(
           hasSearch
-            ? { search: this.search, items, reset: this.reset }
+            ? { search: this.search, items, reset: this.reset, searchTerm }
             : { items, reset: this.reset }
         )}
       </KeyDown>

--- a/src/TreeMenu/renderProps.tsx
+++ b/src/TreeMenu/renderProps.tsx
@@ -20,11 +20,12 @@ export interface TreeMenuItem extends Item {
 
 export type TreeMenuChildren = (props: {
   search?: (term: string) => void;
+  searchTerm?: string;
   items: TreeMenuItem[];
   reset?: (openNodes?: string[]) => void;
 }) => JSX.Element;
 
-export const ItemComponent = ({
+export const ItemComponent: React.FunctionComponent<TreeMenuItem> = ({
   hasNodes = false,
   isOpen = false,
   level = 0,
@@ -35,7 +36,7 @@ export const ItemComponent = ({
   key,
   label = 'unknown',
   style = {},
-}: TreeMenuItem) => (
+}) => (
   <li
     className={classNames(
       'tree-item',

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -6,7 +6,7 @@ import { linkTo } from '@storybook/addon-links';
 import { withInfo } from '@storybook/addon-info';
 
 import { ListGroupItem, Input, ListGroup } from 'reactstrap';
-import TreeMenu from '../src/index';
+import TreeMenu, { defaultChildren } from '../src/index';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../src/sass/index.scss';
@@ -222,24 +222,25 @@ storiesOf('TreeMenu', module)
       )}
     </TreeMenu>
   ))
-  .add('reset openNodes', () => (
-    <TreeMenu data={dataInArray} debounceTime={125} onClickItem={action(`on click node`)}>
-      {({ search, items, reset }) => (
-        <>
-          <button
-            onClick={() => {
-              reset(['reptile']);
-            }}
-          >
-            Reset
-          </button>
-          <Input onChange={e => search(e.target.value)} placeholder="Type and search" />
-          <ListGroup>
-            {items.map(({ reset, ...props }) => (
-              <ListItem {...props} />
-            ))}
-          </ListGroup>
-        </>
-      )}
-    </TreeMenu>
-  ));
+  .add('reset openNodes', () => {
+    return (
+      <TreeMenu
+        data={dataInArray}
+        debounceTime={125}
+        onClickItem={action(`on click node`)}
+      >
+        {({ search, items, reset }) => (
+          <>
+            <button
+              onClick={() => {
+                reset(['reptile']);
+              }}
+            >
+              Reset
+            </button>
+            {defaultChildren({ search, items })}
+          </>
+        )}
+      </TreeMenu>
+    );
+  });


### PR DESCRIPTION
- Reset should also clear `searchTerm`.
- expose `searchTerm` next to `search` function, so user can get `searchTerm` at the root level
