### PR TITLE
Feat/add reset open node on data update

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ import TreeMenu, { defaultChildren, ItemComponent } from 'react-simple-tree-menu
     )}
 </TreeViewMenu>
 
-// add a button to do reset
+// add a button to do resetOpenNodes
 <TreeViewMenu data={treeData}>
-    {({ search, items, reset }) => (
+    {({ search, items, resetOpenNodes }) => (
       <div>
-        <button onClick={reset} />
+        <button onClick={resetOpenNodes} />
         {defaultChildren({search, items})}
       </div>
     )}
@@ -172,7 +172,7 @@ Note the difference between the state `active` and `focused`. ENTER is equivalen
 | locale              | you can provide a function that converts `label` into `string`                                                                           | ({label, ...other}) => string               | ({label}) => label                 |
 | hasSearch           | Set to `false` then `children` will not have the prop `search`                                                                           | boolean                                     | true                               |
 | matchSearch         | you can define your own search function                                                                                                  | ({label, searchTerm, ...other}) => boolean  | ({label, searchTerm}) => isVisible |
-| children            | a render props that provdes two props: `search`, `items` and `reset`                                                                     | (ChildrenProps) => React.ReactNode          | -                                  |
+| children            | a render props that provdes two props: `search`, `items` and `resetOpenNodes`                                                                     | (ChildrenProps) => React.ReactNode          | -                                  |
 
 ### TreeNode
 
@@ -205,12 +205,12 @@ Note the difference between the state `active` and `focused`. ENTER is equivalen
 
 ### ChildrenProps
 
-| props      | description                                                                                              | type                                   | default |
-| ---------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------- |
-| search     | A function that takes a string to filter the label of the item (only available if `hasSearch` is `true`) | (value: string) => void                | -       |
-| searchTerm | the search term that is currently applied (only available if `hasSearch` is `true`)                      | string                                 | -       |
-| items      | An array of `TreeMenuItem`                                                                               | TreeMenuItem[]                         | []      |
-| reset      | A function that resets the `openNodes`, by default it will close all nodes                               | (openNodes: string[]) => void          | -       |
+| props          | description                                                                                              | type                                   | default |
+| -------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------- |
+| search         | A function that takes a string to filter the label of the item (only available if `hasSearch` is `true`) | (value: string) => void                | -       |
+| searchTerm     | the search term that is currently applied (only available if `hasSearch` is `true`)                      | string                                 | -       |
+| items          | An array of `TreeMenuItem`                                                                               | TreeMenuItem[]                         | []      |
+| resetOpenNodes | A function that resets the `openNodes`, by default it will close all nodes                               | (openNodes: string[]) => void          | -       |
 
 ### TreeMenuItem
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-tree-menu",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A simple React tree menu component",
   "keywords": [
     "react",
@@ -110,6 +110,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "fast-memoize": "^2.5.1",
-    "lodash": "^4.17.11"
+    "is-empty": "^1.2.0",
+    "tiny-debounce": "^0.1.1"
   }
 }

--- a/src/TreeMenu/__tests__/__snapshots__/TreeMenu.test.tsx.snap
+++ b/src/TreeMenu/__tests__/__snapshots__/TreeMenu.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`TreeViewMenu should highlight the active node 1`] = `
       "releasenotes/desktop-modeler",
     ]
   }
+  resetOpenNodesOnDataUpdate={false}
 >
   <KeyDown
     down={[Function]}
@@ -310,6 +311,7 @@ exports[`TreeViewMenu should open specified nodes 1`] = `
       "releasenotes/desktop-modeler",
     ]
   }
+  resetOpenNodesOnDataUpdate={false}
 >
   <KeyDown
     down={[Function]}
@@ -567,6 +569,7 @@ exports[`TreeViewMenu should render the level-1 nodes by default 1`] = `
   debounceTime={125}
   hasSearch={true}
   onClickItem={[Function]}
+  resetOpenNodesOnDataUpdate={false}
 >
   <KeyDown
     down={[Function]}

--- a/src/TreeMenu/index.tsx
+++ b/src/TreeMenu/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { debounce } from 'lodash';
+import debounce from 'tiny-debounce';
 
 import walk, {
   TreeNode,
@@ -19,6 +19,7 @@ export type TreeMenuProps = {
   initialFocusKey?: string;
   initialOpenNodes?: string[];
   openNodes?: string[];
+  resetOpenNodesOnDataUpdate?: boolean;
   hasSearch?: boolean;
   onClickItem?: (props: Item) => void;
   debounceTime?: number;
@@ -43,6 +44,7 @@ class TreeMenu extends React.Component<TreeMenuProps, TreeMenuState> {
     debounceTime: 125,
     children: defaultChildren,
     hasSearch: true,
+    resetOpenNodesOnDataUpdate: false,
   };
 
   state: TreeMenuState = {
@@ -52,7 +54,14 @@ class TreeMenu extends React.Component<TreeMenuProps, TreeMenuState> {
     focusKey: this.props.initialFocusKey || '',
   };
 
-  reset = (newOpenNodes?: string[]) => {
+  componentDidUpdate(prevProps: TreeMenuProps) {
+    const { data, initialOpenNodes, resetOpenNodesOnDataUpdate } = this.props;
+    if (prevProps.data !== data && resetOpenNodesOnDataUpdate && initialOpenNodes) {
+      this.setState({ openNodes: initialOpenNodes });
+    }
+  }
+
+  resetOpenNodes = (newOpenNodes?: string[]) => {
     const { initialOpenNodes } = this.props;
     const openNodes =
       (Array.isArray(newOpenNodes) && newOpenNodes) || initialOpenNodes || [];
@@ -160,8 +169,13 @@ class TreeMenu extends React.Component<TreeMenuProps, TreeMenuState> {
       <KeyDown {...keyDownProps}>
         {renderedChildren(
           hasSearch
-            ? { search: this.search, items, reset: this.reset, searchTerm }
-            : { items, reset: this.reset }
+            ? {
+                search: this.search,
+                items,
+                resetOpenNodes: this.resetOpenNodes,
+                searchTerm,
+              }
+            : { items, resetOpenNodes: this.resetOpenNodes }
         )}
       </KeyDown>
     );

--- a/src/TreeMenu/renderProps.tsx
+++ b/src/TreeMenu/renderProps.tsx
@@ -30,7 +30,7 @@ export type TreeMenuChildren = (props: {
   search?: (term: string) => void;
   searchTerm?: string;
   items: TreeMenuItem[];
-  reset?: (openNodes?: string[]) => void;
+  resetOpenNodes?: (openNodes?: string[]) => void;
 }) => JSX.Element;
 
 export const ItemComponent: React.FunctionComponent<TreeMenuItem> = ({

--- a/src/TreeMenu/walk.tsx
+++ b/src/TreeMenu/walk.tsx
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import isEmpty from 'is-empty';
 import memoize from 'fast-memoize';
 
 export interface TreeNodeObject {

--- a/src/typings/modules.d.ts
+++ b/src/typings/modules.d.ts
@@ -1,0 +1,3 @@
+declare module 'tiny-debounce';
+declare module 'is-empty';
+declare module '*.scss';

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -159,6 +159,46 @@ storiesOf('TreeMenu', module)
       initialActiveKey="reptile"
     />
   ))
+  .add('set initial state when data is updated', () => {
+    class TreeMenuWrapper extends React.Component {
+      state = { data: dataInArray };
+      updateData = () =>
+        this.setState(({ data }) => ({
+          data: [
+            ...data,
+            {
+              key: 'foo',
+              label: 'Foo',
+              url: 'https://www.google.com/search?q=foo',
+            },
+          ],
+        }));
+      render() {
+        const { data } = this.state;
+        return (
+          <>
+            <div style={{ padding: '12px', background: 'black' }}>
+              <button style={{ margin: '4px' }} onClick={() => this.updateData()}>
+                Add Foo
+              </button>
+            </div>
+            <TreeMenu
+              data={data}
+              onClickItem={action(`on click node`)}
+              initialOpenNodes={[
+                'reptile',
+                'reptile/squamata',
+                'reptile/squamata/lizard',
+              ]}
+              initialActiveKey="reptile"
+              resetOpenNodesOnDataUpdate
+            />
+          </>
+        );
+      }
+    }
+    return <TreeMenuWrapper />;
+  })
   .add('control TreeMenu from its parent', () => {
     class TreeMenuWrapper extends React.Component {
       state = { openNodes: [] };
@@ -218,7 +258,7 @@ storiesOf('TreeMenu', module)
     />
   ))
   .add('apply other UI framework, e.g. bootstrap', () => (
-    <TreeMenu data={dataInArray} debounceTime={125} onClickItem={action(`on click node`)}>
+    <TreeMenu data={dataInArray} debounceTime={500} onClickItem={action(`on click node`)}>
       {({ search, items }) => (
         <>
           <Input onChange={e => search(e.target.value)} placeholder="Type and search" />
@@ -238,11 +278,11 @@ storiesOf('TreeMenu', module)
         debounceTime={125}
         onClickItem={action(`on click node`)}
       >
-        {({ search, items, reset }) => (
+        {({ search, items, resetOpenNodes }) => (
           <>
             <button
               onClick={() => {
-                reset(['reptile']);
+                resetOpenNodes(['reptile']);
               }}
             >
               Reset

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,11 @@
     "noImplicitAny": true,
     "declaration": true,
     "declarationMap": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "baseUrl": "./src",
+    "paths": {
+      "typings/*": ["typings/*"]
+    }
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6493,6 +6493,11 @@ is-dom@^1.0.9:
   resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.0.9.tgz#483832d52972073de12b9fe3f60320870da8370d"
   integrity sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0=
 
+is-empty@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-empty/-/is-empty-1.2.0.tgz#de9bb5b278738a05a0b09a57e1fb4d4a341a9f6b"
+  integrity sha1-3pu1snhzigWgsJpX4ftNSjQan2s=
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -11632,6 +11637,11 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-debounce@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tiny-debounce/-/tiny-debounce-0.1.1.tgz#e7759447ca1d48830d3b302ce94666a0ca537b1d"
+  integrity sha1-53WUR8odSIMNOzAs6UZmoMpTex0=
 
 tiny-emitter@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
#94 add `resetOpenNodesOnDataUpdate` to let user decide if `openNodes` should be updated when `data` is updated.

Reduce bundle size by replacing `lodash` with other tiny libraries.