### PR TITLE
Bugfix: keydown left breaks when no focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ Note the difference between the state `active` and `focused`. ENTER is equivalen
 | locale              | you can provide a function that converts `label` into `string`                                                                           | ({label, ...other}) => string               | ({label}) => label                 |
 | hasSearch           | Set to `false` then `children` will not have the prop `search`                                                                           | boolean                                     | true                               |
 | matchSearch         | you can define your own search function                                                                                                  | ({label, searchTerm, ...other}) => boolean  | ({label, searchTerm}) => isVisible |
-| children            | a render props that provdes two props: `search`, `items` and `resetOpenNodes`                                                                     | (ChildrenProps) => React.ReactNode          | -                                  |
+| disableKeyboard     | Disable keyboard navigation                                                                                                              | boolean                                     | false                              |
+| children            | a render props that provdes two props: `search`, `items` and `resetOpenNodes`                                                            | (ChildrenProps) => React.ReactNode          | -                                  |
 
 ### TreeNode
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-tree-menu",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A simple React tree menu component",
   "keywords": [
     "react",

--- a/src/TreeMenu/__tests__/__snapshots__/TreeMenu.test.tsx.snap
+++ b/src/TreeMenu/__tests__/__snapshots__/TreeMenu.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`TreeMenu should highlight the active node 1`] = `
     }
   }
   debounceTime={125}
+  disableKeyboard={false}
   hasSearch={true}
   onClickItem={[Function]}
   openNodes={
@@ -303,6 +304,7 @@ exports[`TreeMenu should open specified nodes 1`] = `
     }
   }
   debounceTime={125}
+  disableKeyboard={false}
   hasSearch={true}
   onClickItem={[Function]}
   openNodes={
@@ -567,6 +569,7 @@ exports[`TreeMenu should render the level-1 nodes by default 1`] = `
     }
   }
   debounceTime={125}
+  disableKeyboard={false}
   hasSearch={true}
   onClickItem={[Function]}
   resetOpenNodesOnDataUpdate={false}


### PR DESCRIPTION
#114 

It throws an error when:
- There's no focus yet
- press `left`

Solution:
- if there's no focus, do nothing
- Also made keyboard navigation configurable.