### PR TITLE
feat: set width to 100% of parent not of viewport

### DIFF
--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -16,7 +16,7 @@ $DEFAULT_PADDING: 0.75rem;
   padding-left: 0;
   border-top: 1px solid #ccc;
   text-align: left;
-  width: 100vw;
+  width: 100%;
 }
 
 .rstm-tree-item {


### PR DESCRIPTION
If used in a sidebar or similar environment the width is set by the parent element.